### PR TITLE
Andoid fingerprint prompt fixed

### DIFF
--- a/libs/mobile/src/app/biometrics/index.ts
+++ b/libs/mobile/src/app/biometrics/index.ts
@@ -99,9 +99,9 @@ export async function getBiometricsKeyPair({
       username: "fake1",
       password: "fake2",
     });
+    await fetchCredentialsFromKeyChain({ service: "fake-prompt" });
 
     const { publicKey, privateKey } = generateSec256k1KeyPair();
-    await fetchCredentialsFromKeyChain({ service: "fake-prompt" });
 
     await saveCredentialsToKeyChain({
       service: BIOMETRICS_KEY,

--- a/libs/mobile/src/screens/keys/device/index.tsx
+++ b/libs/mobile/src/screens/keys/device/index.tsx
@@ -91,10 +91,6 @@ export const DeviceKey = observer<DeviceKeyProps>(function DeviceKey({
         )
       );
       setScannedBiometrics(true);
-
-      if (Platform.OS === "android") {
-        await onSubmit();
-      }
     } catch (e) {
       setScannedBiometrics(false);
       await resetBiometricsKeyPair();
@@ -226,6 +222,9 @@ export const DeviceKey = observer<DeviceKeyProps>(function DeviceKey({
                 onSubmit();
               } else {
                 await scanBiometrics();
+                if (Platform.OS !== "ios") {
+                  onSubmit();
+                }
               }
             }}
             autoPress={Platform.OS === "ios"}


### PR DESCRIPTION
finger print prompt pops when tapping on the button, and cancel is handled. close #213 